### PR TITLE
Linux+Proton support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+biggestcookie
+JonLiuFYI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 1.2 (2023-05-15)
+* Added Linux support
+
+## 1.1 (2020-07-04)
+* Added main menu
+* Added saving and loading settings
+
+## 1.0 (2020-06-24)
+Initial release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Borderlands Sensitivity Changer
 
-### [Download it here! (for Windows and Linux+Proton)](https://github.com/biggestcookie/borderlands-sensitivity-changer/releases/latest)
+### [Download for Windows and Linux+Proton here!](https://github.com/biggestcookie/borderlands-sensitivity-changer/releases/latest)
 
 Borderlands 2 and Borderlands: The Pre-Sequel have a minimum sensitivity value of 10, which [can be frustrating when the minimum sensitivity is still too high](https://www.google.com/search?q=borderlands+2+sensitivity+too+high). This program helps you easily change this value yourself lower than the minimum, or any value of your choosing.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Borderlands Sensitivity Changer 1.2
+# Borderlands Sensitivity Changer
 
 ### [Download it here! (for Windows and Linux+Proton)](https://github.com/biggestcookie/borderlands-sensitivity-changer/releases/latest)
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The 'Uncapped Pause Menu Settings' mod for [Borderlands 2](https://www.nexusmods
 
 ### Requirements
 
-[Python 3.8+](https://www.python.org/downloads/)
+[Python 3.10+](https://www.python.org/downloads/)
 
 Install required packages using `pip install -r requirements.txt`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Borderlands Sensitivity Changer
+# Borderlands Sensitivity Changer 1.2
 
-### [Download it here!](https://github.com/biggestcookie/borderlands-sensitivity-changer/releases/latest)
+### [Download it here! (for Windows and Linux+Proton)](https://github.com/biggestcookie/borderlands-sensitivity-changer/releases/latest)
 
 Borderlands 2 and Borderlands: The Pre-Sequel have a minimum sensitivity value of 10, which [can be frustrating when the minimum sensitivity is still too high](https://www.google.com/search?q=borderlands+2+sensitivity+too+high). This program helps you easily change this value yourself lower than the minimum, or any value of your choosing.
 
@@ -14,7 +14,7 @@ Your mouse sensitivity, among other user settings, are stored somewhere in a fil
 
 The built application can be found in the [releases](https://github.com/biggestcookie/borderlands-sensitivity-changer/releases) of this repository. Simply download the application to any location and run it. Make sure you have run the game and have changed some settings at least once before launching.
 
-Currently there is only Windows support.
+This app runs on Windows and Linux. On Linux, it will only work on the Windows version of the game running through Proton, and not the Linux-native port.
 
 ### Demonstration
 
@@ -58,7 +58,7 @@ The 'Uncapped Pause Menu Settings' mod for [Borderlands 2](https://www.nexusmods
 
 ### Requirements
 
-[Python 3.5+](https://www.python.org/downloads/)
+[Python 3.8+](https://www.python.org/downloads/)
 
 Install required packages using `pip install -r requirements.txt`
 

--- a/config.py
+++ b/config.py
@@ -1,5 +1,5 @@
 import json
-import os
+from pathlib import Path
 import platform
 from typing import Any
 
@@ -12,7 +12,7 @@ from util import try_input
 class Config:
     game_choice: Game_Choice
     config_data: Any
-    config_path = f"{os.path.dirname(os.path.abspath(__main__.__file__))}\\config.json"
+    config_path = Path(__main__.__file__).resolve().parent / "config.json"
     _user_os: user_os.UserOS
 
     def __init__(self):

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 import platform
+import sys
 from typing import Any
 
 import __main__
@@ -12,8 +13,13 @@ from util import try_input
 class Config:
     game_choice: Game_Choice
     config_data: Any
-    config_path = Path(__main__.__file__).resolve().parent / "config.json"
     _user_os: user_os.UserOS
+
+    if getattr(sys, 'frozen', False):  # if running as PyInstaller onefile
+        _app_dir = Path(sys.executable).resolve().parent
+    else:
+        _app_dir = Path(__main__.__file__).resolve().parent
+    config_path = _app_dir / "config.json"
 
     def __init__(self):
         text = [

--- a/config.py
+++ b/config.py
@@ -1,30 +1,34 @@
-from enum import Enum
 import json
 import os
+import platform
 from typing import Any
 
 import __main__
+from game_choice import Game_Choice
+import user_os
 from util import try_input
-
-
-class Game_Choice(Enum):
-    BL2 = "Borderlands 2"
-    TPS = "Borderlands The Pre-Sequel"
 
 
 class Config:
     game_choice: Game_Choice
     config_data: Any
     config_path = f"{os.path.dirname(os.path.abspath(__main__.__file__))}\\config.json"
+    _user_os: user_os.UserOS
 
     def __init__(self):
         text = [
             "Which game are you changing sensitivity for?",
             *[f"{i + 1} - {choice.value}" for i, choice in enumerate(Game_Choice)],
         ]
-        self.game_choice = try_input(
+        self.game_choice: Game_Choice = try_input(
             self.__input_to_game_choice, text=text, prompt="Type # and press enter: "
         )
+
+        CurrentUserOS = (
+            user_os.Windows if platform.system() == "Windows" else user_os.Linux
+        )
+        self._user_os = CurrentUserOS(self.game_choice)
+
         self.config_data = self.load_config()
         self.save_config()
 
@@ -51,6 +55,10 @@ class Config:
     def set_data(self, key: str, value: Any):
         self.config_data[self.game_choice.value][key] = value
         self.save_config()
+
+    @property
+    def user_os(self) -> user_os.UserOS:
+        return self._user_os
 
     @staticmethod
     def __input_to_game_choice(input: str) -> Game_Choice:

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,4 @@
+"""Custom exceptions"""
+
+class SaveDataNotFound(Exception):
+    """SaveData folder doesn't exist."""

--- a/game_choice.py
+++ b/game_choice.py
@@ -1,0 +1,9 @@
+"""Enum representing the choice of which game to configure"""
+from enum import Enum
+
+
+class Game_Choice(Enum):
+    """Enum representing the choice of which game to configure"""
+
+    BL2 = "Borderlands 2"
+    TPS = "Borderlands The Pre-Sequel"

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from profiles import get_profile_path
 
 
 def main():
-    profile_path = get_profile_path()
+    profile_path = get_profile_path(CONFIG.user_os)
     print("\nBacking up profile.bin to profile.bin.bak")
     shutil.copyfile(profile_path, f"{profile_path}.bak")
 

--- a/offset.py
+++ b/offset.py
@@ -1,11 +1,12 @@
 import hashlib
+from pathlib import Path
 import random
 
 from config import CONFIG
 from util import try_input
 
 
-def calculate_offset(profile_path: str) -> int:
+def calculate_offset(profile_path: str | Path) -> int:
     while True:
         complete_prompt = "Press enter once you are done. "
         sens_1 = random.randrange(10, 100, 5)
@@ -39,13 +40,13 @@ def calculate_offset(profile_path: str) -> int:
         print("\nUnable to calculate offset! Restarting.")
 
 
-def get_current_sens(profile_path: str, offset: int) -> int:
+def get_current_sens(profile_path: str | Path, offset: int) -> int:
     with open(profile_path, "rb") as f:
         profile = bytearray(f.read()[20:])
         return profile[offset]
 
 
-def rewrite_sens(profile_path: str, offset) -> int:
+def rewrite_sens(profile_path: str | Path, offset) -> int:
     sens = try_input(int, prompt="\nEnter your new desired sensitivity (1-255): ")
     with open(profile_path, "rb") as f:
         profile = bytearray(f.read()[20:])

--- a/profiles.py
+++ b/profiles.py
@@ -1,14 +1,9 @@
 import os
-from pathlib import Path  # to get linux home dir
-import platform
-import string
-from typing import List
-
-if platform.system() == "Windows":
-    from ctypes import windll  # type: ignore
+from pathlib import Path
 
 from config import CONFIG
 from util import try_input
+from user_os import UserOS
 
 
 def input_to_game_path(input: str) -> str:
@@ -21,17 +16,6 @@ def input_to_game_path(input: str) -> str:
     raise Exception("profile.bin not found in given path.")
 
 
-def get_drives() -> List[str]:
-    """Windows-only"""
-    drives: List[str] = []
-    bitmask = windll.kernel32.GetLogicalDrives()
-    for letter in string.ascii_uppercase:
-        if bitmask & 1:
-            drives.append(letter)
-        bitmask >>= 1
-    return drives
-
-
 def get_latest_directory(path: str) -> str:
     return max(
         [os.path.join(path, d) for d in os.listdir(path)],
@@ -39,53 +23,22 @@ def get_latest_directory(path: str) -> str:
     )
 
 
-def get_profile_path() -> str | Path:
+def get_profile_path(user_os: UserOS) -> str | Path:
     save_path: str | None = CONFIG.get_data("path")
-    game_choice = CONFIG.game_choice.value
-
-    # linux-specific values
-    steam_ids = {
-        "Borderlands 2": "49520",
-        "Borderlands The Pre-Sequel": "261640",
-    }
-    id = steam_ids[game_choice]
 
     profile_path = ""
-    if not save_path:
-        if platform.system() == "Windows":
-            path = "{0}:\\Users\\{1}\\Documents\\My Games\\{2}\\WillowGame\\SaveData\\"
-            user = os.environ["USERNAME"]
-            for drive in get_drives():
-                save_path = path.format(drive, user, game_choice)
-                if os.path.exists(save_path):
-                    CONFIG.set_data("path", save_path)
-                    break
-        if platform.system() == "Linux":
-            save_path = f"{Path.home()}/.steam/steam/steamapps/compatdata/{id}/pfx/drive_c/users/steamuser/Documents/My Games/{game_choice}/WillowGame/SaveData/"
-            if Path(save_path).exists():
-                CONFIG.set_data("path", save_path)
+    if save_path is None:
+        save_path = user_os.find_savedata()
+        if save_path is not None:
+            CONFIG.set_data("path", save_path)
 
     try:
         profile_path = Path(get_latest_directory(save_path)) / "profile.bin"  # type: ignore - save_path is no longer None by now
     except FileNotFoundError:
         if not os.path.isfile(profile_path):
-            err_windows = [
-                f"\nCould not find '{game_choice}\\WillowGame\\SaveData'.",
-                f"Please enter the full path to WillowGame, this can usually be found in 'Documents\\My Games\\{game_choice}'.",
-                f"Ex. C:\\Users\\CL4P-TP\\Documents\\My Games\\{game_choice}\\WillowGame",
-            ]
-            err_linux = [
-                f"\nCould not find '{game_choice}/WillowGame/SaveData' for the Proton version of {game_choice}.",
-                f"Please enter the full path to WillowGame, this can usually be found in",
-                f"'steamapps/compatdata/{id}/pfx/drive_c/users/steamuser/Documents/My Games/{game_choice}'.",
-                f"                     ({'^' * len(id)} the Steam ID of {game_choice})",
-                f"Ex. /home/CL4P-TP/.steam/steam/steamapps/ <...> /{game_choice}/WillowGame",
-            ]
-
-            text = err_windows if platform.system == "Windows" else err_linux
             profile_path = try_input(
                 input_to_game_path,
-                text=text,
+                text=user_os.savedata_not_found,
                 error=f"Couldn't find WillowGame at that path. Please try entering your path again: ",
             )
     print(f"\nFound latest profile.bin at {profile_path}")

--- a/profiles.py
+++ b/profiles.py
@@ -1,7 +1,11 @@
-from ctypes import windll
 import os
+from pathlib import Path  # to get linux home dir
+import platform
 import string
 from typing import List
+
+if platform.system() == "Windows":
+    from ctypes import windll  # type: ignore
 
 from config import CONFIG
 from util import try_input
@@ -18,6 +22,7 @@ def input_to_game_path(input: str) -> str:
 
 
 def get_drives() -> List[str]:
+    """Windows-only"""
     drives: List[str] = []
     bitmask = windll.kernel32.GetLogicalDrives()
     for letter in string.ascii_uppercase:
@@ -28,31 +33,56 @@ def get_drives() -> List[str]:
 
 
 def get_latest_directory(path: str) -> str:
-    return max([os.path.join(path, d) for d in os.listdir(path)], key=os.path.getmtime,)
+    return max(
+        [os.path.join(path, d) for d in os.listdir(path)],
+        key=os.path.getmtime,
+    )
 
 
-def get_profile_path() -> str:
-    save_path = CONFIG.get_data("path")
+def get_profile_path() -> str | Path:
+    save_path: str | None = CONFIG.get_data("path")
     game_choice = CONFIG.game_choice.value
+
+    # linux-specific values
+    steam_ids = {
+        "Borderlands 2": "49520",
+        "Borderlands The Pre-Sequel": "261640",
+    }
+    id = steam_ids[game_choice]
 
     profile_path = ""
     if not save_path:
-        path = "{0}:\\Users\\{1}\\Documents\\My Games\\{2}\\WillowGame\\SaveData\\"
-        user = os.environ["USERNAME"]
-        for drive in get_drives():
-            save_path = path.format(drive, user, game_choice)
-            if os.path.exists(save_path):
+        if platform.system() == "Windows":
+            path = "{0}:\\Users\\{1}\\Documents\\My Games\\{2}\\WillowGame\\SaveData\\"
+            user = os.environ["USERNAME"]
+            for drive in get_drives():
+                save_path = path.format(drive, user, game_choice)
+                if os.path.exists(save_path):
+                    CONFIG.set_data("path", save_path)
+                    break
+        if platform.system() == "Linux":
+            save_path = f"{Path.home()}/.steam/steam/steamapps/compatdata/{id}/pfx/drive_c/users/steamuser/Documents/My Games/{game_choice}/WillowGame/SaveData/"
+            if Path(save_path).exists():
                 CONFIG.set_data("path", save_path)
-                break
+
     try:
-        profile_path = f"{get_latest_directory(save_path)}\\profile.bin"
+        profile_path = Path(get_latest_directory(save_path)) / "profile.bin"  # type: ignore - save_path is no longer None by now
     except FileNotFoundError:
         if not os.path.isfile(profile_path):
-            text = [
+            err_windows = [
                 f"\nCould not find '{game_choice}\\WillowGame\\SaveData'.",
                 f"Please enter the full path to WillowGame, this can usually be found in 'Documents\\My Games\\{game_choice}'.",
                 f"Ex. C:\\Users\\CL4P-TP\\Documents\\My Games\\{game_choice}\\WillowGame",
             ]
+            err_linux = [
+                f"\nCould not find '{game_choice}/WillowGame/SaveData' for the Proton version of {game_choice}.",
+                f"Please enter the full path to WillowGame, this can usually be found in",
+                f"'steamapps/compatdata/{id}/pfx/drive_c/users/steamuser/Documents/My Games/{game_choice}'.",
+                f"                     ({'^' * len(id)} the Steam ID of {game_choice})",
+                f"Ex. /home/CL4P-TP/.steam/steam/steamapps/ <...> /{game_choice}/WillowGame",
+            ]
+
+            text = err_windows if platform.system == "Windows" else err_linux
             profile_path = try_input(
                 input_to_game_path,
                 text=text,

--- a/profiles.py
+++ b/profiles.py
@@ -2,44 +2,63 @@ import os
 from pathlib import Path
 
 from config import CONFIG
+from exceptions import SaveDataNotFound
 from util import try_input
 from user_os import UserOS
 
 
 def input_to_game_path(input: str) -> str:
-    save_path = f"{input}\\SaveData\\"
-    if os.path.isdir(save_path):
-        CONFIG.set_data("path", save_path)
-        profile_path = f"{get_latest_directory(save_path)}\\profile.bin"
-        if os.path.isfile(profile_path):
-            return profile_path
+    save_path = Path(input) / "SaveData"
+    if save_path.is_dir():
+        CONFIG.set_data("path", str(save_path))
+        profile_path: Path = get_latest_directory(save_path) / "profile.bin"
+        if profile_path.is_file():
+            return str(profile_path)
     raise Exception("profile.bin not found in given path.")
 
 
-def get_latest_directory(path: str) -> str:
-    return max(
-        [os.path.join(path, d) for d in os.listdir(path)],
-        key=os.path.getmtime,
-    )
+def get_latest_directory(path: Path | None) -> Path:
+    """Return the most recently modified folder within `path`.
+
+    Exceptions that may bubble up:
+    * FileNotFoundError
+    * TypeError - `path` is None, has no subdirectories, or doesn't exist"""
+    if path is None:
+        raise TypeError
+
+    subdirs = filter(lambda p: p.is_dir(), path.iterdir())
+    return max(subdirs, key=lambda p: p.stat().st_mtime)
 
 
 def get_profile_path(user_os: UserOS) -> str | Path:
-    save_path: str | None = CONFIG.get_data("path")
+    save_path_init: str | None = CONFIG.get_data("path")
+    if save_path_init is not None:
+        save_path = Path(save_path_init)
+    else:
+        try:
+            save_path = user_os.find_savedata()
+        except SaveDataNotFound as errpath:
+            save_path = None
+            print(
+                "It seems like your SaveData folder isn't in the usual location,",
+                errpath,
+            )
+        else:
+            CONFIG.set_data("path", str(save_path))
 
-    profile_path = ""
-    if save_path is None:
-        save_path = user_os.find_savedata()
-        if save_path is not None:
-            CONFIG.set_data("path", save_path)
-
+    # Sentinel value that almost certainly isn't valid a valid Path on a normal
+    # person's PC. This is extremely cursed and hacky. (Linear A Sign A661)
+    profile_path = Path("𐜳")
     try:
-        profile_path = Path(get_latest_directory(save_path)) / "profile.bin"  # type: ignore - save_path is no longer None by now
-    except FileNotFoundError:
-        if not os.path.isfile(profile_path):
+        latest_subdir = get_latest_directory(save_path)
+        profile_path = Path(latest_subdir) / "profile.bin"
+    except (TypeError, FileNotFoundError):
+        if not profile_path.is_file():
             profile_path = try_input(
                 input_to_game_path,
                 text=user_os.savedata_not_found,
                 error=f"Couldn't find WillowGame at that path. Please try entering your path again: ",
             )
+
     print(f"\nFound latest profile.bin at {profile_path}")
     return profile_path

--- a/user_os.py
+++ b/user_os.py
@@ -1,0 +1,89 @@
+"""Platform-specific behaviors that must be implemented for each supported OS"""
+
+from abc import ABC, abstractmethod
+import os
+from pathlib import Path
+
+from game_choice import Game_Choice
+
+
+class UserOS(ABC):
+    """Base class for platform-specific things needed to find profile.bin"""
+
+    def __init__(self, game_choice: Game_Choice) -> None:
+        self.game: str = game_choice.value
+
+    @property
+    @abstractmethod
+    def savedata_not_found(self) -> list[str]:
+        """Error message if the path to SaveData wasn't found"""
+        pass
+
+    @abstractmethod
+    def find_savedata(self) -> str | None:
+        """Return an absolute path to the chosen game's default save location
+        (where profile.bin is), or None if it wasn't found.
+        """
+        pass
+
+
+class Linux(UserOS):
+    def __init__(self, game_choice: Game_Choice) -> None:
+        super().__init__(game_choice)
+        steam_ids = {
+            "Borderlands 2": "49520",
+            "Borderlands The Pre-Sequel": "261640",
+        }
+        self._steamid = steam_ids[self.game]
+        self._errmsg = [
+            f"\nCould not find '{self.game}/WillowGame/SaveData' for the Proton version of {self.game}.",
+            f"Please enter the full path to WillowGame, this can usually be found in",
+            f"'steamapps/compatdata/{id}/pfx/drive_c/users/steamuser/Documents/My Games/{self.game}'.",
+            f"                     ({'^' * len(self._steamid)} the Steam ID of {self.game})",
+            f"Ex. /home/CL4P-TP/.steam/steam/steamapps/ <...> /{self.game}/WillowGame",
+        ]
+
+    @property
+    def savedata_not_found(self) -> list[str]:
+        return self._errmsg
+
+    def find_savedata(self) -> str | None:
+        save_path = f"{Path.home()}/.steam/steam/steamapps/compatdata/{self._steamid}/pfx/drive_c/users/steamuser/Documents/My Games/{self.game}/WillowGame/SaveData/"
+        return save_path if Path(save_path).exists() else None
+
+
+class Windows(UserOS):
+    def __init__(self, game_choice: Game_Choice) -> None:
+        super().__init__(game_choice)
+        self._errmsg = [
+            f"\nCould not find '{self.game}\\WillowGame\\SaveData'.",
+            f"Please enter the full path to WillowGame, this can usually be found in 'Documents\\My Games\\{self.game}'.",
+            f"Ex. C:\\Users\\CL4P-TP\\Documents\\My Games\\{self.game}\\WillowGame",
+        ]
+
+    @staticmethod
+    def get_drives() -> list[str]:
+        from ctypes import windll  # type: ignore
+        import string
+
+        drives: list[str] = []
+        bitmask = windll.kernel32.GetLogicalDrives()
+        for letter in string.ascii_uppercase:
+            if bitmask & 1:
+                drives.append(letter)
+            bitmask >>= 1
+        return drives
+
+    @property
+    def savedata_not_found(self) -> list[str]:
+        return self._errmsg
+
+    def find_savedata(self) -> str | None:
+        path = "{0}:\\Users\\{1}\\Documents\\My Games\\{2}\\WillowGame\\SaveData\\"
+        user = os.environ["USERNAME"]
+        for drive in self.get_drives():
+            save_path = path.format(drive, user, self.game)
+            if os.path.exists(save_path):
+                return save_path
+
+        return None


### PR DESCRIPTION
When complete, this closes #2 and increases the version number to 1.2.

## Tasks
- [x] Abstract away Windows/Linux differences from `profiles.py`
- [x] Conditionally import ctypes windll
- [x] Change Windows-specific hardcoded paths (like config.json) to work on linux
- [x] Update README: python min ver (3.8?), OS support
- [x] Authors file

## Acceptance
- [x] Works on Windows without regressions
- [x] Reproduce that it works on Linux+Proton
- [x] Works with PyInstaller

## After merging
Build and release version 1.2 for
- [ ] Windows
- [ ] Linux